### PR TITLE
ctype tolower toupper expect unsigned char

### DIFF
--- a/components/cmd_router/cmd_router.c
+++ b/components/cmd_router/cmd_router.c
@@ -48,13 +48,13 @@ void preprocess_string(char* str)
             if (*p <= '9')
                 a = *p - '0';
             else
-                a = toupper(*p) - 'A' + 10;
+                a = toupper((unsigned char)*p) - 'A' + 10;
             a <<= 4;
             p++;
             if (*p <= '9')
                 a += *p - '0';
             else
-                a += toupper(*p) - 'A' + 10;
+                a += toupper((unsigned char)*p) - 'A' + 10;
             *q++ = a;
         }
         else if (*(p) == '+') {


### PR DESCRIPTION
Hi, 

when trying to compile the code, I got the error

```
In file included from /home/fix_jer/GIT/esp32_nat_router/components/cmd_router/cmd_router.c:10:0:
/home/fix_jer/GIT/esp32_nat_router/components/cmd_router/cmd_router.c: In function 'preprocess_string':
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:57:54: error: array subscript has type 'char' [-Werror=char-subscripts]
 #define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
                                                      ^
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:61:24: note: in expansion of macro '__ctype_lookup'
 #define islower(__c) ((__ctype_lookup(__c)&(_U|_L))==_L)
                        ^
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:86:7: note: in expansion of macro 'islower'
       islower (__x) ? (int) __x - 'a' + 'A' : (int) __x;})
       ^
/home/fix_jer/GIT/esp32_nat_router/components/cmd_router/cmd_router.c:51:21: note: in expansion of macro 'toupper'
                 a = toupper(*p) - 'A' + 10;
                     ^
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:57:54: error: array subscript has type 'char' [-Werror=char-subscripts]
 #define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
                                                      ^
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:61:24: note: in expansion of macro '__ctype_lookup'
 #define islower(__c) ((__ctype_lookup(__c)&(_U|_L))==_L)
                        ^
/home/fix_jer/esp/esp-idf/components/newlib/include/ctype.h:86:7: note: in expansion of macro 'islower'
       islower (__x) ? (int) __x - 'a' + 'A' : (int) __x;})
       ^
/home/fix_jer/GIT/esp32_nat_router/components/cmd_router/cmd_router.c:57:22: note: in expansion of macro 'toupper'
                 a += toupper(*p) - 'A' + 10;
```

The ctype tolower, toupper functions are expecting unsigned char, not char , hence this proposal