### PR TITLE
Lock on ESPIDF 5.3.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = main
 
 [env:ttgo-lora32-v1]
-platform = espressif32
+platform = espressif32@^5.3.0
 framework = espidf
 board = ttgo-lora32-v1
 
@@ -20,7 +20,7 @@ monitor_speed = 115200
 monitor_flags = --raw
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@^5.3.0
 framework = espidf
 board = esp32dev
 
@@ -28,7 +28,7 @@ monitor_speed = 115200
 monitor_flags = --raw
 
 [env:esp32-c3-devkitm-1]
-platform = espressif32
+platform = espressif32@^5.3.0
 board = esp32-c3-devkitm-1
 framework = espidf
 


### PR DESCRIPTION
As of today, ESPIDF is 6.0.1 and current code didn't works. You should go back to 5.3.0