### PR TITLE
Ability to change MAC addresses

### DIFF
--- a/components/cmd_router/cmd_router.c
+++ b/components/cmd_router/cmd_router.c
@@ -39,7 +39,7 @@ static const char *TAG = "cmd_router";
 
 static void register_set_sta(void);
 static void register_set_sta_static(void);
-static void register_set_sta_mac(void);
+static void register_set_mac(void);
 static void register_set_ap(void);
 static void register_set_ap_ip(void);
 static void register_show(void);
@@ -144,7 +144,7 @@ void register_router(void)
 {
     register_set_sta();
     register_set_sta_static();
-    register_set_sta_mac();
+    register_set_mac();
     register_set_ap();
     register_set_ap_ip();
     register_portmap();
@@ -294,7 +294,7 @@ static void register_set_sta_static(void)
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
 }
 
-/** Arguments used by 'set_sta_mac' function */
+/** Arguments used by 'set_mac' function */
 static struct {
     struct arg_int *mac0;
     struct arg_int *mac1;
@@ -303,15 +303,15 @@ static struct {
     struct arg_int *mac4;
     struct arg_int *mac5;
     struct arg_end *end;
-} set_sta_mac_args;
+} set_mac_arg;
 
-int set_sta_mac(int argc, char **argv) {
+esp_err_t set_mac(const char *key, const char *interface, int argc, char **argv) {
     esp_err_t err;
     nvs_handle_t nvs;
 
-    int nerrors = arg_parse(argc, argv, (void **) &set_sta_mac_args);
+    int nerrors = arg_parse(argc, argv, (void **) &set_mac_arg);
     if (nerrors != 0) {
-        arg_print_errors(stderr, set_sta_mac_args.end, argv[0]);
+        arg_print_errors(stderr, set_mac_arg.end, argv[0]);
         return 1;
     }
 
@@ -320,36 +320,53 @@ int set_sta_mac(int argc, char **argv) {
         return err;
     }
 
-    uint8_t mac[] = {set_sta_mac_args.mac0->ival[0], set_sta_mac_args.mac1->ival[0], set_sta_mac_args.mac2->ival[0], set_sta_mac_args.mac3->ival[0], set_sta_mac_args.mac4->ival[0], set_sta_mac_args.mac5->ival[0]};
-    err = nvs_set_blob(nvs, "mac", mac, sizeof(mac));
+    uint8_t mac[] = {set_mac_arg.mac0->ival[0], set_mac_arg.mac1->ival[0], set_mac_arg.mac2->ival[0], set_mac_arg.mac3->ival[0], set_mac_arg.mac4->ival[0], set_mac_arg.mac5->ival[0]};
+    err = nvs_set_blob(nvs, key, mac, sizeof(mac));
     if (err == ESP_OK) {
         err = nvs_commit(nvs);
         if (err == ESP_OK) {
-            ESP_LOGI(TAG, "STA mac address %u:%u:%u:%u:%u:%u stored.", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+            ESP_LOGI(TAG, "%s mac address %02X:%02X:%02X:%02X:%02X:%02X stored.", interface, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
         }
     }
     nvs_close(nvs);
     return err;
 }
 
-static void register_set_sta_mac(void)
-{
-    set_sta_mac_args.mac0 = arg_int1(NULL, NULL, "<octet>", "First octet");
-    set_sta_mac_args.mac1 = arg_int1(NULL, NULL, "<octet>", "Second octet");
-    set_sta_mac_args.mac2 = arg_int1(NULL, NULL, "<octet>", "Third octet");
-    set_sta_mac_args.mac3 = arg_int1(NULL, NULL, "<octet>", "Fourth octet");
-    set_sta_mac_args.mac4 = arg_int1(NULL, NULL, "<octet>", "Fifth octet");
-    set_sta_mac_args.mac5 = arg_int1(NULL, NULL, "<octet>", "Sixth octet");
-    set_sta_mac_args.end = arg_end(6);
+int set_sta_mac(int argc, char **argv) {
+    return set_mac("mac", "STA", argc, argv);
+}
 
-    const esp_console_cmd_t cmd = {
-            .command = "set_sta_mac",
-            .help = "Set MAC address for the STA interface",
-            .hint = NULL,
-            .func = &set_sta_mac,
-            .argtable = &set_sta_mac_args
+int set_ap_mac(int argc, char **argv) {
+    return set_mac("ap_mac", "AP", argc, argv);
+}
+
+static void register_set_mac(void)
+{
+    set_mac_arg.mac0 = arg_int1(NULL, NULL, "<octet>", "First octet");
+    set_mac_arg.mac1 = arg_int1(NULL, NULL, "<octet>", "Second octet");
+    set_mac_arg.mac2 = arg_int1(NULL, NULL, "<octet>", "Third octet");
+    set_mac_arg.mac3 = arg_int1(NULL, NULL, "<octet>", "Fourth octet");
+    set_mac_arg.mac4 = arg_int1(NULL, NULL, "<octet>", "Fifth octet");
+    set_mac_arg.mac5 = arg_int1(NULL, NULL, "<octet>", "Sixth octet");
+    set_mac_arg.end = arg_end(6);
+
+    const esp_console_cmd_t cmd_sta = {
+        .command = "set_sta_mac",
+        .help = "Set MAC address of the STA interface",
+        .hint = NULL,
+        .func = &set_sta_mac,
+        .argtable = &set_mac_arg
     };
-    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
+    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_sta) );
+
+    const esp_console_cmd_t cmd_ap = {
+        .command = "set_ap_mac",
+        .help = "Set MAC address of the AP interface",
+        .hint = NULL,
+        .func = &set_ap_mac,
+        .argtable = &set_mac_arg
+    };
+    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_ap) );
 }
 
 /** Arguments used by 'set_ap' function */

--- a/components/cmd_router/router_globals.h
+++ b/components/cmd_router/router_globals.h
@@ -36,6 +36,7 @@ int set_sta(int argc, char **argv);
 int set_sta_static(int argc, char **argv);
 int set_ap(int argc, char **argv);
 
+esp_err_t get_config_param_blob(char* name, uint8_t** blob, size_t blob_len);
 esp_err_t get_config_param_int(char* name, int* param);
 esp_err_t get_config_param_str(char* name, char** param);
 

--- a/main/esp32_nat_router.c
+++ b/main/esp32_nat_router.c
@@ -531,6 +531,7 @@ char* passwd = NULL;
 char* static_ip = NULL;
 char* subnet_mask = NULL;
 char* gateway_addr = NULL;
+uint8_t* ap_mac = NULL;
 char* ap_ssid = NULL;
 char* ap_passwd = NULL;
 char* ap_ip = NULL;
@@ -581,6 +582,7 @@ void app_main(void)
     if (gateway_addr == NULL) {
         gateway_addr = param_set_default("");
     }
+    get_config_param_blob("ap_mac", &ap_mac, 6);
     get_config_param_str("ap_ssid", &ap_ssid);
     if (ap_ssid == NULL) {
         ap_ssid = param_set_default("ESP32_NAT_Router");
@@ -597,7 +599,7 @@ void app_main(void)
     get_portmap_tab();
 
     // Setup WIFI
-    wifi_init(mac, ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, NULL, ap_ssid, ap_passwd, ap_ip);
+    wifi_init(mac, ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, ap_mac, ap_ssid, ap_passwd, ap_ip);
 
     pthread_t t1;
     pthread_create(&t1, NULL, led_status_thread, NULL);

--- a/main/esp32_nat_router.c
+++ b/main/esp32_nat_router.c
@@ -484,13 +484,11 @@ void wifi_init(const char* ssid, const char* ent_username, const char* ent_ident
             esp_eap_client_set_password((uint8_t *)passwd, strlen(passwd)); //provide password
             esp_wifi_sta_enterprise_enable();
         }
-
-        ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &ap_config) );
     } else {
         ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP) );
-        ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &ap_config) );        
     }
 
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &ap_config) );
 
 
     // Enable DNS (offer) for dhcp server

--- a/main/esp32_nat_router.c
+++ b/main/esp32_nat_router.c
@@ -523,6 +523,7 @@ void wifi_init(const uint8_t* mac, const char* ssid, const char* ent_username, c
     }
 }
 
+uint8_t* mac = NULL;
 char* ssid = NULL;
 char* ent_username = NULL;
 char* ent_identity = NULL;
@@ -551,6 +552,7 @@ void app_main(void)
     ESP_LOGI(TAG, "Command history disabled");
 #endif
 
+    get_config_param_blob("mac", &mac, 6);
     get_config_param_str("ssid", &ssid);
     if (ssid == NULL) {
         ssid = param_set_default("");
@@ -595,7 +597,7 @@ void app_main(void)
     get_portmap_tab();
 
     // Setup WIFI
-    wifi_init(NULL, ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, NULL, ap_ssid, ap_passwd, ap_ip);
+    wifi_init(mac, ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, NULL, ap_ssid, ap_passwd, ap_ip);
 
     pthread_t t1;
     pthread_create(&t1, NULL, led_status_thread, NULL);

--- a/main/esp32_nat_router.c
+++ b/main/esp32_nat_router.c
@@ -394,7 +394,7 @@ const int CONNECTED_BIT = BIT0;
 #define JOIN_TIMEOUT_MS (2000)
 
 
-void wifi_init(const char* ssid, const char* ent_username, const char* ent_identity, const char* passwd, const char* static_ip, const char* subnet_mask, const char* gateway_addr, const char* ap_ssid, const char* ap_passwd, const char* ap_ip)
+void wifi_init(const uint8_t* mac, const char* ssid, const char* ent_username, const char* ent_identity, const char* passwd, const char* static_ip, const char* subnet_mask, const char* gateway_addr, const uint8_t* ap_mac, const char* ap_ssid, const char* ap_passwd, const char* ap_ip)
 {
     esp_netif_dns_info_t dnsserver;
     // esp_netif_dns_info_t dnsinfo;
@@ -484,11 +484,19 @@ void wifi_init(const char* ssid, const char* ent_username, const char* ent_ident
             esp_eap_client_set_password((uint8_t *)passwd, strlen(passwd)); //provide password
             esp_wifi_sta_enterprise_enable();
         }
+
+        if (mac != NULL) {
+            ESP_ERROR_CHECK(esp_wifi_set_mac(ESP_IF_WIFI_STA, mac));
+        }
     } else {
         ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP) );
     }
 
     ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &ap_config) );
+
+    if (ap_mac != NULL) {
+        ESP_ERROR_CHECK(esp_wifi_set_mac(ESP_IF_WIFI_AP, ap_mac));
+    }
 
 
     // Enable DNS (offer) for dhcp server
@@ -587,7 +595,7 @@ void app_main(void)
     get_portmap_tab();
 
     // Setup WIFI
-    wifi_init(ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, ap_ssid, ap_passwd, ap_ip);
+    wifi_init(NULL, ssid, ent_username, ent_identity, passwd, static_ip, subnet_mask, gateway_addr, NULL, ap_ssid, ap_passwd, ap_ip);
 
     pthread_t t1;
     pthread_create(&t1, NULL, led_status_thread, NULL);


### PR DESCRIPTION
Resolves #64, resolves #113

```
set_sta_mac  <octet> <octet> <octet> <octet> <octet> <octet>
  Set MAC address of the STA interface
       <octet>  First octet
       <octet>  Second octet
       <octet>  Third octet
       <octet>  Fourth octet
       <octet>  Fifth octet
       <octet>  Sixth octet

set_ap_mac  <octet> <octet> <octet> <octet> <octet> <octet>
  Set MAC address of the AP interface
       <octet>  First octet
       <octet>  Second octet
       <octet>  Third octet
       <octet>  Fourth octet
       <octet>  Fifth octet
       <octet>  Sixth octet
```

e.g. use `set_sta_mac 255 255 255 255 255 255` in order to set MAC address of STA interface to `FF:FF:FF:FF:FF:FF`
