### PR TITLE
Add support for WS2812 multicolor led

### DIFF
--- a/components/led_strip/CMakeLists.txt
+++ b/components/led_strip/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS led_strip_api.c led_strip_rmt_dev.c led_strip_rmt_encoder.c
+                    INCLUDE_DIRS . include interface
+                    REQUIRES driver)

--- a/components/led_strip/include/led_strip.h
+++ b/components/led_strip/include/led_strip.h
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "led_strip_rmt.h"
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+#include "led_strip_spi.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set RGB for a specific pixel
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param red: red part of color
+ * @param green: green part of color
+ * @param blue: blue part of color
+ *
+ * @return
+ *      - ESP_OK: Set RGB for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of invalid parameters
+ *      - ESP_FAIL: Set RGB for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
+
+/**
+ * @brief Set RGBW for a specific pixel
+ *
+ * @note Only call this function if your led strip does have the white component (e.g. SK6812-RGBW)
+ * @note Also see `led_strip_set_pixel` if you only want to specify the RGB part of the color and bypass the white component
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param red: red part of color
+ * @param green: green part of color
+ * @param blue: blue part of color
+ * @param white: separate white component
+ *
+ * @return
+ *      - ESP_OK: Set RGBW color for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set RGBW color for a specific pixel failed because of an invalid argument
+ *      - ESP_FAIL: Set RGBW color for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white);
+
+/**
+ * @brief Set HSV for a specific pixel
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param hue: hue part of color (0 - 360)
+ * @param saturation: saturation part of color (0 - 255)
+ * @param value: value part of color (0 - 255)
+ *
+ * @return
+ *      - ESP_OK: Set HSV color for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set HSV color for a specific pixel failed because of an invalid argument
+ *      - ESP_FAIL: Set HSV color for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint8_t saturation, uint8_t value);
+
+/**
+ * @brief Refresh memory colors to LEDs
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Refresh successfully
+ *      - ESP_FAIL: Refresh failed because some other error occurred
+ *
+ * @note:
+ *      After updating the LED colors in the memory, a following invocation of this API is needed to flush colors to strip.
+ */
+esp_err_t led_strip_refresh(led_strip_handle_t strip);
+
+/**
+ * @brief Clear LED strip (turn off all LEDs)
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Clear LEDs successfully
+ *      - ESP_FAIL: Clear LEDs failed because some other error occurred
+ */
+esp_err_t led_strip_clear(led_strip_handle_t strip);
+
+/**
+ * @brief Free LED strip resources
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Free resources successfully
+ *      - ESP_FAIL: Free resources failed because error occurred
+ */
+esp_err_t led_strip_del(led_strip_handle_t strip);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/led_strip/include/led_strip_rmt.h
+++ b/components/led_strip/include/led_strip_rmt.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "led_strip_types.h"
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "driver/rmt_types.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LED Strip RMT specific configuration
+ */
+typedef struct {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+    uint8_t rmt_channel;        /*!< Specify the channel number, the legacy RMT driver doesn't support channel allocator */
+#else // new driver supports specify the clock source and clock resolution
+    rmt_clock_source_t clk_src; /*!< RMT clock source */
+    uint32_t resolution_hz;     /*!< RMT tick resolution, if set to zero, a default resolution (10MHz) will be applied */
+#endif
+    size_t mem_block_symbols;   /*!< How many RMT symbols can one RMT channel hold at one time. Set to 0 will fallback to use the default size. */
+    struct {
+        uint32_t with_dma: 1;   /*!< Use DMA to transmit data */
+    } flags;                    /*!< Extra driver flags */
+} led_strip_rmt_config_t;
+
+/**
+ * @brief Create LED strip based on RMT TX channel
+ *
+ * @param led_config LED strip configuration
+ * @param rmt_config RMT specific configuration
+ * @param ret_strip Returned LED strip handle
+ * @return
+ *      - ESP_OK: create LED strip handle successfully
+ *      - ESP_ERR_INVALID_ARG: create LED strip handle failed because of invalid argument
+ *      - ESP_ERR_NO_MEM: create LED strip handle failed because of out of memory
+ *      - ESP_FAIL: create LED strip handle failed because some other error
+ */
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const led_strip_rmt_config_t *rmt_config, led_strip_handle_t *ret_strip);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/led_strip/include/led_strip_spi.h
+++ b/components/led_strip/include/led_strip_spi.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "driver/spi_master.h"
+#include "led_strip_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LED Strip SPI specific configuration
+ */
+typedef struct {
+    spi_clock_source_t clk_src; /*!< SPI clock source */
+    spi_host_device_t spi_bus;  /*!< SPI bus ID. Which buses are available depends on the specific chip */
+    struct {
+        uint32_t with_dma: 1;   /*!< Use DMA to transmit data */
+    } flags;                    /*!< Extra driver flags */
+} led_strip_spi_config_t;
+
+/**
+ * @brief Create LED strip based on SPI MOSI channel
+ * @note Although only the MOSI line is used for generating the signal, the whole SPI bus can't be used for other purposes.
+ *
+ * @param led_config LED strip configuration
+ * @param spi_config SPI specific configuration
+ * @param ret_strip Returned LED strip handle
+ * @return
+ *      - ESP_OK: create LED strip handle successfully
+ *      - ESP_ERR_INVALID_ARG: create LED strip handle failed because of invalid argument
+ *      - ESP_ERR_NOT_SUPPORTED: create LED strip handle failed because of unsupported configuration
+ *      - ESP_ERR_NO_MEM: create LED strip handle failed because of out of memory
+ *      - ESP_FAIL: create LED strip handle failed because some other error
+ */
+esp_err_t led_strip_new_spi_device(const led_strip_config_t *led_config, const led_strip_spi_config_t *spi_config, led_strip_handle_t *ret_strip);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/led_strip/include/led_strip_types.h
+++ b/components/led_strip/include/led_strip_types.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LED strip pixel format
+ */
+typedef enum {
+    LED_PIXEL_FORMAT_GRB,    /*!< Pixel format: GRB */
+    LED_PIXEL_FORMAT_GRBW,   /*!< Pixel format: GRBW */
+    LED_PIXEL_FORMAT_INVALID /*!< Invalid pixel format */
+} led_pixel_format_t;
+
+/**
+ * @brief LED strip model
+ * @note Different led model may have different timing parameters, so we need to distinguish them.
+ */
+typedef enum {
+    LED_MODEL_WS2812, /*!< LED strip model: WS2812 */
+    LED_MODEL_SK6812, /*!< LED strip model: SK6812 */
+    LED_MODEL_INVALID /*!< Invalid LED strip model */
+} led_model_t;
+
+/**
+ * @brief LED strip handle
+ */
+typedef struct led_strip_t *led_strip_handle_t;
+
+/**
+ * @brief LED Strip Configuration
+ */
+typedef struct {
+    int strip_gpio_num;      /*!< GPIO number that used by LED strip */
+    uint32_t max_leds;       /*!< Maximum LEDs in a single strip */
+    led_pixel_format_t led_pixel_format; /*!< LED pixel format */
+    led_model_t led_model;   /*!< LED model */
+
+    struct {
+        uint32_t invert_out: 1; /*!< Invert output signal */
+    } flags;                    /*!< Extra driver flags */
+} led_strip_config_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/led_strip/interface/led_strip_interface.h
+++ b/components/led_strip/interface/led_strip_interface.h
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct led_strip_t led_strip_t; /*!< Type of LED strip */
+
+/**
+ * @brief LED strip interface definition
+ */
+struct led_strip_t {
+    /**
+     * @brief Set RGB for a specific pixel
+     *
+     * @param strip: LED strip
+     * @param index: index of pixel to set
+     * @param red: red part of color
+     * @param green: green part of color
+     * @param blue: blue part of color
+     *
+     * @return
+     *      - ESP_OK: Set RGB for a specific pixel successfully
+     *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of invalid parameters
+     *      - ESP_FAIL: Set RGB for a specific pixel failed because other error occurred
+     */
+    esp_err_t (*set_pixel)(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
+
+    /**
+     * @brief Set RGBW for a specific pixel. Similar to `set_pixel` but also set the white component
+     *
+     * @param strip: LED strip
+     * @param index: index of pixel to set
+     * @param red: red part of color
+     * @param green: green part of color
+     * @param blue: blue part of color
+     * @param white: separate white component
+     *
+     * @return
+     *      - ESP_OK: Set RGBW color for a specific pixel successfully
+     *      - ESP_ERR_INVALID_ARG: Set RGBW color for a specific pixel failed because of an invalid argument
+     *      - ESP_FAIL: Set RGBW color for a specific pixel failed because other error occurred
+     */
+    esp_err_t (*set_pixel_rgbw)(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white);
+
+    /**
+     * @brief Refresh memory colors to LEDs
+     *
+     * @param strip: LED strip
+     * @param timeout_ms: timeout value for refreshing task
+     *
+     * @return
+     *      - ESP_OK: Refresh successfully
+     *      - ESP_FAIL: Refresh failed because some other error occurred
+     *
+     * @note:
+     *      After updating the LED colors in the memory, a following invocation of this API is needed to flush colors to strip.
+     */
+    esp_err_t (*refresh)(led_strip_t *strip);
+
+    /**
+     * @brief Clear LED strip (turn off all LEDs)
+     *
+     * @param strip: LED strip
+     * @param timeout_ms: timeout value for clearing task
+     *
+     * @return
+     *      - ESP_OK: Clear LEDs successfully
+     *      - ESP_FAIL: Clear LEDs failed because some other error occurred
+     */
+    esp_err_t (*clear)(led_strip_t *strip);
+
+    /**
+     * @brief Free LED strip resources
+     *
+     * @param strip: LED strip
+     *
+     * @return
+     *      - ESP_OK: Free resources successfully
+     *      - ESP_FAIL: Free resources failed because error occurred
+     */
+    esp_err_t (*del)(led_strip_t *strip);
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/led_strip/led_strip_api.c
+++ b/components/led_strip/led_strip_api.c
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "esp_log.h"
+#include "esp_check.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+
+static const char *TAG = "led_strip";
+
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->set_pixel(strip, index, red, green, blue);
+}
+
+esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint8_t saturation, uint8_t value)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+
+    uint32_t red = 0;
+    uint32_t green = 0;
+    uint32_t blue = 0;
+
+    uint32_t rgb_max = value;
+    uint32_t rgb_min = rgb_max * (255 - saturation) / 255.0f;
+
+    uint32_t i = hue / 60;
+    uint32_t diff = hue % 60;
+
+    // RGB adjustment amount by hue
+    uint32_t rgb_adj = (rgb_max - rgb_min) * diff / 60;
+
+    switch (i) {
+    case 0:
+        red = rgb_max;
+        green = rgb_min + rgb_adj;
+        blue = rgb_min;
+        break;
+    case 1:
+        red = rgb_max - rgb_adj;
+        green = rgb_max;
+        blue = rgb_min;
+        break;
+    case 2:
+        red = rgb_min;
+        green = rgb_max;
+        blue = rgb_min + rgb_adj;
+        break;
+    case 3:
+        red = rgb_min;
+        green = rgb_max - rgb_adj;
+        blue = rgb_max;
+        break;
+    case 4:
+        red = rgb_min + rgb_adj;
+        green = rgb_min;
+        blue = rgb_max;
+        break;
+    default:
+        red = rgb_max;
+        green = rgb_min;
+        blue = rgb_max - rgb_adj;
+        break;
+    }
+
+    return strip->set_pixel(strip, index, red, green, blue);
+}
+
+esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->set_pixel_rgbw(strip, index, red, green, blue, white);
+}
+
+esp_err_t led_strip_refresh(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->refresh(strip);
+}
+
+esp_err_t led_strip_clear(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->clear(strip);
+}
+
+esp_err_t led_strip_del(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->del(strip);
+}

--- a/components/led_strip/led_strip_rmt_dev.c
+++ b/components/led_strip/led_strip_rmt_dev.c
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "driver/rmt_tx.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+#include "led_strip_rmt_encoder.h"
+
+#define LED_STRIP_RMT_DEFAULT_RESOLUTION 10000000 // 10MHz resolution
+#define LED_STRIP_RMT_DEFAULT_TRANS_QUEUE_SIZE 4
+// the memory size of each RMT channel, in words (4 bytes)
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 64
+#else
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 48
+#endif
+
+static const char *TAG = "led_strip_rmt";
+
+typedef struct {
+    led_strip_t base;
+    rmt_channel_handle_t rmt_chan;
+    rmt_encoder_handle_t strip_encoder;
+    uint32_t strip_len;
+    uint8_t bytes_per_pixel;
+    uint8_t pixel_buf[];
+} led_strip_rmt_obj;
+
+static esp_err_t led_strip_rmt_set_pixel(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_FALSE(index < rmt_strip->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
+    uint32_t start = index * rmt_strip->bytes_per_pixel;
+    // In thr order of GRB, as LED strip like WS2812 sends out pixels in this order
+    rmt_strip->pixel_buf[start + 0] = green & 0xFF;
+    rmt_strip->pixel_buf[start + 1] = red & 0xFF;
+    rmt_strip->pixel_buf[start + 2] = blue & 0xFF;
+    if (rmt_strip->bytes_per_pixel > 3) {
+        rmt_strip->pixel_buf[start + 3] = 0;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_set_pixel_rgbw(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_FALSE(index < rmt_strip->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
+    ESP_RETURN_ON_FALSE(rmt_strip->bytes_per_pixel == 4, ESP_ERR_INVALID_ARG, TAG, "wrong LED pixel format, expected 4 bytes per pixel");
+    uint8_t *buf_start = rmt_strip->pixel_buf + index * 4;
+    // SK6812 component order is GRBW
+    *buf_start = green & 0xFF;
+    *++buf_start = red & 0xFF;
+    *++buf_start = blue & 0xFF;
+    *++buf_start = white & 0xFF;
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_refresh(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    rmt_transmit_config_t tx_conf = {
+        .loop_count = 0,
+    };
+
+    ESP_RETURN_ON_ERROR(rmt_enable(rmt_strip->rmt_chan), TAG, "enable RMT channel failed");
+    ESP_RETURN_ON_ERROR(rmt_transmit(rmt_strip->rmt_chan, rmt_strip->strip_encoder, rmt_strip->pixel_buf,
+                                     rmt_strip->strip_len * rmt_strip->bytes_per_pixel, &tx_conf), TAG, "transmit pixels by RMT failed");
+    ESP_RETURN_ON_ERROR(rmt_tx_wait_all_done(rmt_strip->rmt_chan, -1), TAG, "flush RMT channel failed");
+    ESP_RETURN_ON_ERROR(rmt_disable(rmt_strip->rmt_chan), TAG, "disable RMT channel failed");
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_clear(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    // Write zero to turn off all leds
+    memset(rmt_strip->pixel_buf, 0, rmt_strip->strip_len * rmt_strip->bytes_per_pixel);
+    return led_strip_rmt_refresh(strip);
+}
+
+static esp_err_t led_strip_rmt_del(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_ERROR(rmt_del_channel(rmt_strip->rmt_chan), TAG, "delete RMT channel failed");
+    ESP_RETURN_ON_ERROR(rmt_del_encoder(rmt_strip->strip_encoder), TAG, "delete strip encoder failed");
+    free(rmt_strip);
+    return ESP_OK;
+}
+
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const led_strip_rmt_config_t *rmt_config, led_strip_handle_t *ret_strip)
+{
+    led_strip_rmt_obj *rmt_strip = NULL;
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(led_config && rmt_config && ret_strip, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    ESP_GOTO_ON_FALSE(led_config->led_pixel_format < LED_PIXEL_FORMAT_INVALID, ESP_ERR_INVALID_ARG, err, TAG, "invalid led_pixel_format");
+    uint8_t bytes_per_pixel = 3;
+    if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRBW) {
+        bytes_per_pixel = 4;
+    } else if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRB) {
+        bytes_per_pixel = 3;
+    } else {
+        assert(false);
+    }
+    rmt_strip = calloc(1, sizeof(led_strip_rmt_obj) + led_config->max_leds * bytes_per_pixel);
+    ESP_GOTO_ON_FALSE(rmt_strip, ESP_ERR_NO_MEM, err, TAG, "no mem for rmt strip");
+    uint32_t resolution = rmt_config->resolution_hz ? rmt_config->resolution_hz : LED_STRIP_RMT_DEFAULT_RESOLUTION;
+
+    // for backward compatibility, if the user does not set the clk_src, use the default value
+    rmt_clock_source_t clk_src = RMT_CLK_SRC_DEFAULT;
+    if (rmt_config->clk_src) {
+        clk_src = rmt_config->clk_src;
+    }
+    size_t mem_block_symbols = LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS;
+    // override the default value if the user sets it
+    if (rmt_config->mem_block_symbols) {
+        mem_block_symbols = rmt_config->mem_block_symbols;
+    }
+    rmt_tx_channel_config_t rmt_chan_config = {
+        .clk_src = clk_src,
+        .gpio_num = led_config->strip_gpio_num,
+        .mem_block_symbols = mem_block_symbols,
+        .resolution_hz = resolution,
+        .trans_queue_depth = LED_STRIP_RMT_DEFAULT_TRANS_QUEUE_SIZE,
+        .flags.with_dma = rmt_config->flags.with_dma,
+        .flags.invert_out = led_config->flags.invert_out,
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_tx_channel(&rmt_chan_config, &rmt_strip->rmt_chan), err, TAG, "create RMT TX channel failed");
+
+    led_strip_encoder_config_t strip_encoder_conf = {
+        .resolution = resolution,
+        .led_model = led_config->led_model
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_led_strip_encoder(&strip_encoder_conf, &rmt_strip->strip_encoder), err, TAG, "create LED strip encoder failed");
+
+
+    rmt_strip->bytes_per_pixel = bytes_per_pixel;
+    rmt_strip->strip_len = led_config->max_leds;
+    rmt_strip->base.set_pixel = led_strip_rmt_set_pixel;
+    rmt_strip->base.set_pixel_rgbw = led_strip_rmt_set_pixel_rgbw;
+    rmt_strip->base.refresh = led_strip_rmt_refresh;
+    rmt_strip->base.clear = led_strip_rmt_clear;
+    rmt_strip->base.del = led_strip_rmt_del;
+
+    *ret_strip = &rmt_strip->base;
+    return ESP_OK;
+err:
+    if (rmt_strip) {
+        if (rmt_strip->rmt_chan) {
+            rmt_del_channel(rmt_strip->rmt_chan);
+        }
+        if (rmt_strip->strip_encoder) {
+            rmt_del_encoder(rmt_strip->strip_encoder);
+        }
+        free(rmt_strip);
+    }
+    return ret;
+}

--- a/components/led_strip/led_strip_rmt_encoder.c
+++ b/components/led_strip/led_strip_rmt_encoder.c
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_check.h"
+#include "led_strip_rmt_encoder.h"
+
+static const char *TAG = "led_rmt_encoder";
+
+typedef struct {
+    rmt_encoder_t base;
+    rmt_encoder_t *bytes_encoder;
+    rmt_encoder_t *copy_encoder;
+    int state;
+    rmt_symbol_word_t reset_code;
+} rmt_led_strip_encoder_t;
+
+static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
+    rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
+    rmt_encode_state_t session_state = 0;
+    rmt_encode_state_t state = 0;
+    size_t encoded_symbols = 0;
+    switch (led_encoder->state) {
+    case 0: // send RGB data
+        encoded_symbols += bytes_encoder->encode(bytes_encoder, channel, primary_data, data_size, &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = 1; // switch to next state when current encoding session finished
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    // fall-through
+    case 1: // send reset code
+        encoded_symbols += copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code,
+                                                sizeof(led_encoder->reset_code), &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = 0; // back to the initial encoding session
+            state |= RMT_ENCODING_COMPLETE;
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    }
+out:
+    *ret_state = state;
+    return encoded_symbols;
+}
+
+static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_del_encoder(led_encoder->bytes_encoder);
+    rmt_del_encoder(led_encoder->copy_encoder);
+    free(led_encoder);
+    return ESP_OK;
+}
+
+static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_reset(led_encoder->bytes_encoder);
+    rmt_encoder_reset(led_encoder->copy_encoder);
+    led_encoder->state = 0;
+    return ESP_OK;
+}
+
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder)
+{
+    esp_err_t ret = ESP_OK;
+    rmt_led_strip_encoder_t *led_encoder = NULL;
+    ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    ESP_GOTO_ON_FALSE(config->led_model < LED_MODEL_INVALID, ESP_ERR_INVALID_ARG, err, TAG, "invalid led model");
+    led_encoder = calloc(1, sizeof(rmt_led_strip_encoder_t));
+    ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG, "no mem for led strip encoder");
+    led_encoder->base.encode = rmt_encode_led_strip;
+    led_encoder->base.del = rmt_del_led_strip_encoder;
+    led_encoder->base.reset = rmt_led_strip_encoder_reset;
+    rmt_bytes_encoder_config_t bytes_encoder_config;
+    if (config->led_model == LED_MODEL_SK6812) {
+        bytes_encoder_config = (rmt_bytes_encoder_config_t) {
+            .bit0 = {
+                .level0 = 1,
+                .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+                .level1 = 0,
+                .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+            },
+            .bit1 = {
+                .level0 = 1,
+                .duration0 = 0.6 * config->resolution / 1000000, // T1H=0.6us
+                .level1 = 0,
+                .duration1 = 0.6 * config->resolution / 1000000, // T1L=0.6us
+            },
+            .flags.msb_first = 1 // SK6812 transfer bit order: G7...G0R7...R0B7...B0(W7...W0)
+        };
+    } else if (config->led_model == LED_MODEL_WS2812) {
+        // different led strip might have its own timing requirements, following parameter is for WS2812
+        bytes_encoder_config = (rmt_bytes_encoder_config_t) {
+            .bit0 = {
+                .level0 = 1,
+                .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+                .level1 = 0,
+                .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+            },
+            .bit1 = {
+                .level0 = 1,
+                .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
+                .level1 = 0,
+                .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
+            },
+            .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
+        };
+    } else {
+        assert(false);
+    }
+    ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
+    rmt_copy_encoder_config_t copy_encoder_config = {};
+    ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
+
+    uint32_t reset_ticks = config->resolution / 1000000 * 280 / 2; // reset code duration defaults to 280us to accomodate WS2812B-V5
+    led_encoder->reset_code = (rmt_symbol_word_t) {
+        .level0 = 0,
+        .duration0 = reset_ticks,
+        .level1 = 0,
+        .duration1 = reset_ticks,
+    };
+    *ret_encoder = &led_encoder->base;
+    return ESP_OK;
+err:
+    if (led_encoder) {
+        if (led_encoder->bytes_encoder) {
+            rmt_del_encoder(led_encoder->bytes_encoder);
+        }
+        if (led_encoder->copy_encoder) {
+            rmt_del_encoder(led_encoder->copy_encoder);
+        }
+        free(led_encoder);
+    }
+    return ret;
+}

--- a/components/led_strip/led_strip_rmt_encoder.h
+++ b/components/led_strip/led_strip_rmt_encoder.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "driver/rmt_encoder.h"
+#include "led_strip_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of led strip encoder configuration
+ */
+typedef struct {
+    uint32_t resolution;   /*!< Encoder resolution, in Hz */
+    led_model_t led_model; /*!< LED model */
+} led_strip_encoder_config_t;
+
+/**
+ * @brief Create RMT encoder for encoding LED strip pixels into RMT symbols
+ *
+ * @param[in] config Encoder configuration
+ * @param[out] ret_encoder Returned encoder handle
+ * @return
+ *      - ESP_ERR_INVALID_ARG for any invalid arguments
+ *      - ESP_ERR_NO_MEM out of memory when creating led strip encoder
+ *      - ESP_OK if creating encoder successfully
+ */
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS "esp32_nat_router.c"
                             "http_server.c"
+                            "led_status.c"
                     INCLUDE_DIRS ".")
 
 set_source_files_properties(http_server.c

--- a/main/esp32_nat_router.c
+++ b/main/esp32_nat_router.c
@@ -35,6 +35,7 @@
 #include "dhcpserver/dhcpserver_options.h"
 
 #include "cmd_decl.h"
+#include "led_status.h"
 #include <esp_http_server.h>
 
 #if !IP_NAPT
@@ -323,27 +324,6 @@ static void initialize_console(void)
     /* Load command history from filesystem */
     linenoiseHistoryLoad(HISTORY_PATH);
 #endif
-}
-
-void * led_status_thread(void * p)
-{
-    gpio_reset_pin(BLINK_GPIO);
-    gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT);
-
-    while (true)
-    {
-        gpio_set_level(BLINK_GPIO, ap_connect);
-
-        for (int i = 0; i < connect_count; i++)
-        {
-            gpio_set_level(BLINK_GPIO, 1 - ap_connect);
-            vTaskDelay(50 / portTICK_PERIOD_MS);
-            gpio_set_level(BLINK_GPIO, ap_connect);
-            vTaskDelay(50 / portTICK_PERIOD_MS);
-        }
-
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-    }
 }
 
 static void wifi_event_handler(void* arg, esp_event_base_t event_base,

--- a/main/led_status.c
+++ b/main/led_status.c
@@ -1,0 +1,76 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "router_globals.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP32C6
+#include "led_strip.h"
+#define BLINK_GPIO 8
+
+static led_strip_handle_t led_strip;
+
+static void blink_led(int led_state)
+{
+    if (led_state) {
+        /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+        led_strip_set_pixel(led_strip, 0, 16, 16, 16);
+        led_strip_refresh(led_strip);
+    } else {
+        led_strip_clear(led_strip);
+    }
+}
+
+static void configure_led(void)
+{
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = BLINK_GPIO,
+        .max_leds = 1,
+    };
+    led_strip_rmt_config_t rmt_config = {
+        .resolution_hz = 10 * 1000 * 1000,
+        .flags.with_dma = false,
+    };
+    ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
+    led_strip_clear(led_strip);
+}
+
+#else
+// On board LED
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+#define BLINK_GPIO 44
+#else
+#define BLINK_GPIO 2
+#endif
+
+static void blink_led(int led_state)
+{
+    gpio_set_level(BLINK_GPIO, led_state);
+}
+
+static void configure_led(void)
+{
+    gpio_reset_pin(BLINK_GPIO);
+    gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT);
+}
+
+#endif
+
+void * led_status_thread(void * p)
+{
+    configure_led();
+
+    while (true)
+    {
+        blink_led(ap_connect);
+
+        for (int i = 0; i < connect_count; i++)
+        {
+            blink_led(1 - ap_connect);
+            vTaskDelay(50 / portTICK_PERIOD_MS);
+            blink_led(ap_connect);
+            vTaskDelay(50 / portTICK_PERIOD_MS);
+        }
+
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+}

--- a/main/led_status.h
+++ b/main/led_status.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Register system functions
+void * led_status_thread(void * p);

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,8 @@
 src_dir = main
 
 [env]
-platform = espressif32@^6.4.0
+platform = espressif32@^6.6.0
 framework = espidf
-platform_packages =
-        framework-espidf @ https://github.com/tasmota/esp-idf/releases/download/v5.1.2-org/esp-idf-v5.1.2-org.zip
 board_build.partitions = partitions_example.csv
 monitor_filters = direct
 monitor_speed = 115200
@@ -28,6 +26,12 @@ board = esp32-c3-devkitm-1
 
 [env:esp32-s3]
 board = esp32s3box
+
+[env:esp32-c6-devkitc-1]
+board = esp32-c6-devkitc-1
+
+[env:esp32-c6-devkitm-1]
+board = esp32-c6-devkitm-1
 
 ; [env:esp32-s3-debug]
 ; extends = env:esp32-s3


### PR DESCRIPTION
New feature:

- Support for WS2812 LED

Changes:

- Update PlatformIO espressif32 to 6.6.0 (esp-idf 5.2.1)
- Add led_strip component [espressif/led_strip@2.5.3](https://components.espressif.com/components/espressif/led_strip)
- Extract led_status method into its own file

Tested on boards:

- ESP32 (UART)
- ESP32-C6 (USB Serial)