### PR TITLE
fix: fix the conditon check variable

### DIFF
--- a/main/http_server.c
+++ b/main/http_server.c
@@ -108,12 +108,12 @@ static esp_err_t index_get_handler(httpd_req_t *req)
                             //Password
                             argv[argc++] = param2;
                             //Username
-                            if(strlen(param2)) {
+                            if(strlen(param3)) {
                                 argv[argc++] = "-u";
                                 argv[argc++] = param3;
                             }
                             //Identity
-                            if(strlen(param3)) {
+                            if(strlen(param4)) {
                                 argv[argc++] = "-a";
                                 argv[argc++] = param4;
                             }


### PR DESCRIPTION
This condition checks the length of 'param2' (password) instead of 'param3' (ent_username) before adding '-u' and 'ent_username' to the arguments. It should check if 'param3' is not empty.

This condition checks the length of 'param3' (ent_username) instead of 'param4' (ent_identity) before adding '-a' and 'ent_identity' to the arguments. It should check if 'param4' is not empty.