### PR TITLE
Fix build: espressif32 locked on 6.5.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = main
 
 [env]
-platform = espressif32@^6.4.0
+platform = espressif32@6.5.0
 framework = espidf
 platform_packages =
         framework-espidf @ https://github.com/tasmota/esp-idf/releases/download/v5.1.2-org/esp-idf-v5.1.2-org.zip


### PR DESCRIPTION
Platform espressif32 should be locked on 6.5.0: last platform to build successfully with linked framework-espidf